### PR TITLE
fix: setup-tools.mk

### DIFF
--- a/scripts/setup-tools.mk
+++ b/scripts/setup-tools.mk
@@ -6,6 +6,7 @@ brew-common:
 	brew list kustomize || brew install kustomize
 	brew list k9s || brew install k9s
 	brew list fluxcd/tap/flux || brew install fluxcd/tap/flux
+	brew list kind || brew install kind
 
 python-common:
 	pip install kafka-python


### PR DESCRIPTION
should list/install Kubernetes kind in order to successfully create Kubernetes Cluster using "make k8s-create-cluster"